### PR TITLE
Fix formatting issues based on JSch links

### DIFF
--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -41,7 +41,7 @@ You can configure the _SFTP Session Factory_ via a regular bean definition:
 ----
 
 Every time an adapter requests a session object from its `SessionFactory`, a new SFTP session is being created.
-Under the covers, the SFTP Session Factory relies on thehttp://www.jcraft.com/jsch/[JSch] library to provide the SFTP capabilities.
+Under the covers, the SFTP Session Factory relies on the http://www.jcraft.com/jsch/[JSch] library to provide the SFTP capabilities.
 
 However, Spring Integration also supports the caching of SFTP sessions, please see <<sftp-session-caching>> for more information.
 
@@ -84,7 +84,7 @@ It's default depends on the underlying JSch version but it will look like:_SSH-2
 
 If `true`, all threads will be daemon threads.
 If set to `false`, normal non-daemon threads will be used instead.
-This property will be set on the underlyinghttp://www.jcraft.com/jsch/[JSch]`Session`.
+This property will be set on the underlying http://epaul.github.io/jsch-documentation/javadoc/com/jcraft/jsch/Session.html[Session].
 There, this property will default to `false`, if not explicitly set.
 
 *host*


### PR DESCRIPTION
There're a few small formatting issues referencing JSch links.